### PR TITLE
Architecture bug

### DIFF
--- a/install.js
+++ b/install.js
@@ -20,12 +20,12 @@ var npmconf = require('npmconf');
 var util = require('util');
 
 var libPath = path.join(__dirname, 'lib', 'bin', 'iedriver');
-var downloadUrl = 'http://selenium.googlecode.com/files/IEDriverServer_';
+var downloadUrl = 'http://selenium-release.storage.googleapis.com/2.40/IEDriverServer_';
 
 if (process.arch === 'x64') {
-  downloadUrl += 'x64_2.39.0.zip';
+  downloadUrl += 'x64_2.40.0.zip';
 } else {
-  downloadUrl += 'Win32_2.39.0.zip';
+  downloadUrl += 'Win32_2.40.0.zip';
 }
 
 


### PR DESCRIPTION
IEDriverServer is downloaded for wrong architecture.

IEDriverServer_x64_2.39.0.zip is downloaded for Win32 which results in:

```
$ dalek test-script.js -b IE
Running tests
>> ERROR: Error: spawn Unknown system errno 216
```

IEDriverServer_Win32_2.39.0 works, however, fine in 64-bit windows.

I also updated the driver version to 2.40.

Keep up the good work! DalekJS rocks!
