### PR TITLE
Parse non-english tasklist, force kill

### DIFF
--- a/index.js
+++ b/index.js
@@ -359,7 +359,9 @@ var InternetExplorer = {
             head[i] = head[i].replace(/ /gi,'');
           }
 
-          if (head.indexOf('PID')<0) head[1] = 'PID'
+          if (head.indexOf('PID')<0){
+            head[1] = 'PID';
+          }
         } else {
           var tmp = {};
           for (var j=0;j<rec.length;j++){


### PR DESCRIPTION
On a non-english Windows, the csv output of `tasklist /FO CSV` has non-english headers. As reported at dalekjs/dalek-browser-ie#10, running this:

``` javascript
var ie = require('dalek-browser-ie');
ie._list(console.log.bind(console));
```

Results in entries like:

``` javascript
{ Imagenaam: 'chrome.exe',
  'Proces-id': '8184',
  Sessienaam: 'Console',
  'Sessienr.': '1',
  Geheugengebruik: '22.196 kB' }
```

I.e., the `PID` key that dalek-browser-ie expects, is in Dutch (`Proces-id`). Because of this underlying bug, IE will not be closed after running tests. This PR fixes that by assuming that the second CSV column is the PID. I'm not sure if the column order can be guaranteed. To be safe, the script tests if the PID is an integer.

Additionally, I've found that a forced kill is required more often than not.

I'm on Win7 64bit, using IE 11.0.9600.17105, Dalek CLI 0.0.4, Dalek local 0.0.8.
