### PR TITLE
Fix screenshot for IE11

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,8 @@ var InternetExplorer = {
    */
 
   desiredCapabilities: {
-    browserName: 'InternetExplorer'
+    browserName: 'InternetExplorer',
+    initialBrowserUrl: ''
   },
 
   /**


### PR DESCRIPTION
When the method screenshot is done in IE11, the dalek is closed. I've seen this issue: https://code.google.com/p/selenium/issues/detail?id=6511 , and I tried to add the parameter initialBrowserUrl, and it works.
